### PR TITLE
Ignore KDevelop-generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ sfwt
 
 build
 
+# KDevelop stuff
+.kdev4
+*.kdev4


### PR DESCRIPTION
We should generally put files generated by other (more) common IDEs in the .gitignore (Visual Studio, Code::Blocks etc.).
